### PR TITLE
Use 'image()' instead of 'heatmap()' to plot the QR code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: qrcode
 Type: Package
 Title: QRcode Generator for R
-Version: 0.1.1
+Version: 0.1.2
 Date: 2015-08-13
 Author: Victor Teh
 Maintainer: Victor Teh <victorteh@gmail.com>

--- a/R/qrcode_gen.R
+++ b/R/qrcode_gen.R
@@ -48,7 +48,14 @@ qrcode_gen <- function(dataString,ErrorCorrectionLevel='L',dataOutput = FALSE, p
     #apply mask
     dataMasked <- qrMask(data,qrInfo,mask)
     if(plotQRcode){
-      heatmap(dataMasked[nrow(dataMasked):1,],Rowv = NA, Colv = NA,scale="none",col=c(wColor,bColor),labRow ='',labCol = '')
+      # temporarily get rid of margins
+      opar <- par(mar = c(0,0,0,0))
+      on.exit( par(opar) )
+      # get matrix dimensions
+      nc = ncol(dataMasked)
+      nr = nrow(dataMasked)
+      # plot the QR matrix
+      image(1L:nc, 1L:nr, t(dataMasked), xlim = 0.5 + c(0, nc), ylim = 0.5 + c(nr, 0), axes = FALSE, xlab = "", ylab = "", col = c(wColor, bColor), asp = 1)
     }
     if(dataOutput){
       return(dataMasked)


### PR DESCRIPTION
Hi Victor,
thank you for your great package, it's very useful for generating and plotting QR codes in R.

I've come across the issue that the generated images have blank margins at the right hand side and at the bottom. When inspecting the code I've noticed that for plotting you use the function `heatmap`. This is a higher-level function, which internally calls `image` to plot the matrix. As you don't use the additional functionality provided by `heatmap`, it is probably better to call `image` directly, which is faster. I've used this approach when setting the margins to zero.

Thank you for considering my contribution. I'm looking forward to hearing from you.

Cheers,
Andrzej
